### PR TITLE
Passes test kitchen except for Centos 6.6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,6 @@ suites:
       vault:
         config:
           disable_mlock: true
+          backend_type: 'file'
+          backend_options:
+            path: '/home/vault/storage'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,8 +14,10 @@ default['vault']['bag_item'] = 'vault'
 default['vault']['version'] = '0.1.2'
 
 default['vault']['config']['path'] = '/home/vault/.vault.json'
-default['vault']['config']['listen_address'] = '127.0.0.1:8200'
-default['vault']['config']['tls_disable'] = false
+default['vault']['config']['address'] = '127.0.0.1:8200'
+# for vault.config.tls_disable, only "" evaluates to false
+# anything else is either an error, or evaluates to true
+default['vault']['config']['tls_disable'] = ""
 default['vault']['config']['tls_cert_file'] = '/etc/vault/ssl/certs/vault.crt'
 default['vault']['config']['tls_key_file'] = '/etc/vault/ssl/private/vault.key'
 

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -27,7 +27,7 @@ class Chef::Resource::VaultConfig < Chef::Resource
   attribute(:address, kind_of: String)  # formerly :listen_address
   # for Vault configuration: tls_disable, only "" evaluates to false
   # @see @see https://vaultproject.io/docs/config/index.html
-  # 'If non-empty, then TLS will be disabled. This is an opt-in; Vault assumes by default that TLS will be used.'
+  # 'If non-empty, then TLS will be disabled'
   attribute(:tls_disable, kind_of: String, default: "")
   attribute(:tls_cert_file, kind_of: String)
   attribute(:tls_key_file, kind_of: String)
@@ -38,7 +38,7 @@ class Chef::Resource::VaultConfig < Chef::Resource
   attribute(:backend_options, option_collector: true)
 
   def tls?
-    !tls_disable
+    tls_disable.match(/^$/)
   end
 
   # Transforms the resource into a JSON format which matches the
@@ -65,8 +65,8 @@ class Chef::Resource::VaultConfig < Chef::Resource
         directory ::File.dirname(new_resource.tls_cert_file) do
           recursive true
           owner 'root'
-          group 'root'
-          mode '0644'
+          group new_resource.group
+          mode '0755'
         end
 
         item = chef_vault_item(node['vault']['bag_name'], node['vault']['bag_item'])
@@ -79,9 +79,9 @@ class Chef::Resource::VaultConfig < Chef::Resource
 
         directory ::File.dirname(new_resource.tls_key_file) do
           recursive true
-          mode '0640'
+          mode '0750'
           owner 'root'
-          group 'root'
+          group new_resource.group
         end
 
         file new_resource.tls_key_file do

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -24,8 +24,11 @@ class Chef::Resource::VaultConfig < Chef::Resource
   attribute(:group, kind_of: String, default: 'vault')
 
   # @see https://vaultproject.io/docs/config/index.html
-  attribute(:listen_address, kind_of: String)
-  attribute(:tls_disable, equal_to: [true, false], default: false)
+  attribute(:address, kind_of: String)  # formerly :listen_address
+  # for Vault configuration: tls_disable, only "" evaluates to false
+  # @see @see https://vaultproject.io/docs/config/index.html
+  # 'If non-empty, then TLS will be disabled. This is an opt-in; Vault assumes by default that TLS will be used.'
+  attribute(:tls_disable, kind_of: String, default: "")
   attribute(:tls_cert_file, kind_of: String)
   attribute(:tls_key_file, kind_of: String)
   attribute(:disable_mlock, equal_to: [true, false], default: false)
@@ -42,10 +45,15 @@ class Chef::Resource::VaultConfig < Chef::Resource
   # Vault service's configuration format.
   # @see https://vaultproject.io/docs/config/index.html
   def to_json
-    for_keeps = %i{listen_address tls_disable tls_cert_file tls_key_file disable_mlock statsite_addr statsd_addr}
+    listener_keeps = %i{address tls_disable tls_cert_file tls_key_file}
+    listener_options = to_hash.keep_if do |k,v|
+      listener_keeps.include?(k.to_sym)
+    end
+    config_keeps = %i{disable_mlock statsite_addr statsd_addr}
     config = to_hash.keep_if do |k, v|
-      for_keeps.include?(k.to_sym)
+      config_keeps.include?(k.to_sym)
     end.merge('backend' => { backend_type => (backend_options || {}) })
+    config.merge!('listener' => { 'tcp' => listener_options })
     JSON.pretty_generate(config, quirks_mode: true)
   end
 

--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -58,7 +58,7 @@ class Chef::Resource::VaultService < Chef::Resource
   attribute(:source_url, kind_of: String)
 
   def command
-    "vault server -config=#{config_path}"
+    "/usr/local/bin/vault server -config=#{config_path}"
   end
 
   def binary_checksum

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -25,7 +25,11 @@ describe service('vault') do
   it { should be_running }
 end
 
-describe file('/etc/ssl/certs/vault.crt') do
+describe port(8200) do
+  it { should be_listening }
+end
+
+describe file('/etc/vault/ssl/certs/vault.crt') do
   it { should contain '-----BEGIN CERTIFICATE-----' }
   it { should contain '-----END CERTIFICATE-----' }
   it { should be_file }
@@ -34,7 +38,7 @@ describe file('/etc/ssl/certs/vault.crt') do
   it { should be_mode 644 }
 end
 
-describe file('/etc/ssl/private/vault.key') do
+describe file('/etc/vault/ssl/private/vault.key') do
   it { should contain '-----BEGIN RSA PRIVATE KEY-----' }
   it { should contain '-----END RSA PRIVATE KEY-----' }
   it { should be_file }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe command('which vault') do
+describe command('/usr/local/bin/vault -v') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match '/usr/local/bin/vault' }
+  its(:stdout) { should match 'Vault v0.1.2' }
 end
 
 describe group('vault') do


### PR DESCRIPTION
I wanted to get my own vault server up for testing so I started with your cookbook. Changes include:

- vault.json to put the network options in the 'transport: tcp' block
- tls_disabled is not a Boolean, only "" evaluates as false
- explicilty use binary path to work with Centos 7 systemd
- kitchen uses 'file' backend to be more useful in testing (optional: didn't actually mean to include this but it passes the tests this way so leaving in for now).

Tests:
- paths in serverspec SSL cert tests should match cookbook
- replaced 'which' with command /usr/local/bin/vault since which was failing in 7.1 for some reason