### PR TITLE
fixing default attributes based on HWRP

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,8 +14,7 @@ default['vault']['bag_item'] = 'vault'
 default['vault']['version'] = '0.1.2'
 
 default['vault']['config']['path'] = '/home/vault/.vault.json'
-default['vault']['config']['listen_address'] = '127.0.0.1:8200'
-default['vault']['config']['tls_disable'] = false
+default['vault']['config']['address'] = '127.0.0.1:8200'
 default['vault']['config']['tls_cert_file'] = '/etc/vault/ssl/certs/vault.crt'
 default['vault']['config']['tls_key_file'] = '/etc/vault/ssl/private/vault.key'
 


### PR DESCRIPTION
There were two default attributes that might have been missed on the last rework of the vault_config HWRP. 

``` attribute(:address, kind_of: String)  # formerly :listen_address```

```attribute(:tls_disable, kind_of: String, default: "")```

Based on this information I removed the tls_disable default as it was a bool and we are expecting a string, in addition we default that string in the provider.   

listen_address was also updated based on the comments.


As always, great work on this cookbook @johnbellone. 