### PR TITLE
give ability to control whether this cookbook manages the ssl cert

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,8 @@ default['vault']['service_name'] = 'vault'
 default['vault']['service_user'] = 'vault'
 default['vault']['service_group'] = 'vault'
 
+# Chef-vault required for certificate management
+default['vault']['manage_certificate'] = true
 default['vault']['bag_name'] = 'secrets'
 default['vault']['bag_item'] = 'vault'
 

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -74,30 +74,32 @@ module VaultCookbook
               mode '0755'
             end
 
-            item = chef_vault_item(
-              new_resource.bag_name,
-              new_resource.bag_item
-            )
-            file new_resource.tls_cert_file do
-              content item['certificate']
-              mode '0644'
-              owner new_resource.user
-              group new_resource.group
-            end
+            if node['vault']['manage_certificate']
+              item = chef_vault_item(
+                new_resource.bag_name,
+                new_resource.bag_item
+              )
+              file new_resource.tls_cert_file do
+                content item['certificate']
+                mode '0644'
+                owner new_resource.user
+                group new_resource.group
+              end
 
-            directory ::File.dirname(new_resource.tls_key_file) do
-              recursive true
-              mode '0750'
-              owner 'root'
-              group new_resource.group
-            end
+              directory ::File.dirname(new_resource.tls_key_file) do
+                recursive true
+                mode '0750'
+                owner 'root'
+                group new_resource.group
+              end
 
-            file new_resource.tls_key_file do
-              sensitive true
-              content item['private_key']
-              mode '0640'
-              owner new_resource.user
-              group new_resource.group
+              file new_resource.tls_key_file do
+                sensitive true
+                content item['private_key']
+                mode '0640'
+                owner new_resource.user
+                group new_resource.group
+              end
             end
           end
 


### PR DESCRIPTION
First, let me just say this is a completely optional PR and entirely up to you if you wish to include this.  I don't use chef-vault and plan to manage the certificates manually(initially) with my vault implementation.    The cookbook was failing expecting some chef-vault integration.  

This simply gives the ability to control whether the cookbook manages the SSL certificate.  Default behavior is still set to true to be consistent with how the cookbook currently works.

Thanks again for an awesome cookbook!