### PR TITLE
Fix tls_disable with vault 0.2.0

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -28,7 +28,7 @@ module VaultCookbook
 
       # @see https://vaultproject.io/docs/config/index.html
       attribute(:address, kind_of: String)  # formerly :listen_address
-      attribute(:tls_disable, kind_of: String, default: 'false')
+      attribute(:tls_disable, kind_of: String, required: false, default: nil)
       attribute(:tls_cert_file, kind_of: String)
       attribute(:tls_key_file, kind_of: String)
       attribute(:bag_name, kind_of: String, default: 'secrets')
@@ -47,10 +47,11 @@ module VaultCookbook
       # Vault service's configuration format.
       # @see https://vaultproject.io/docs/config/index.html
       def to_json
-        listener_keeps = %i{address tls_disable tls_cert_file tls_key_file}
+        listener_keeps = %i{address tls_cert_file tls_key_file}
         listener_options = to_hash.keep_if do |k, _|
-          listener_keeps.include?(k.to_sym)
+            listener_keeps.include?(k.to_sym)
         end
+        listener_options.put(:tls_disable) if tls_disable != nil
         config_keeps = %i{disable_mlock statsite_addr statsd_addr}
         config = to_hash.keep_if do |k, _|
           config_keeps.include?(k.to_sym)

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -28,7 +28,7 @@ module VaultCookbook
 
       # @see https://vaultproject.io/docs/config/index.html
       attribute(:address, kind_of: String)  # formerly :listen_address
-      attribute(:tls_disable, kind_of: String, default: '')
+      attribute(:tls_disable, kind_of: String, default: 'false')
       attribute(:tls_cert_file, kind_of: String)
       attribute(:tls_key_file, kind_of: String)
       attribute(:bag_name, kind_of: String, default: 'secrets')
@@ -40,7 +40,7 @@ module VaultCookbook
       attribute(:backend_options, option_collector: true)
 
       def tls?
-        tls_disable.match(/^$/)
+        tls_disable == "true"
       end
 
       # Transforms the resource into a JSON format which matches the

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -40,7 +40,7 @@ module VaultCookbook
       attribute(:backend_options, option_collector: true)
 
       def tls?
-        tls_disable == "true"
+        tls_disable != nil
       end
 
       # Transforms the resource into a JSON format which matches the


### PR DESCRIPTION
This fix should be backwards compatible but I have not tested.  Resolving issue https://github.com/johnbellone/vault-cookbook/issues/8 which I filed earlier.