### PR TITLE
Make the TLS certificate management optional

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,3 +15,20 @@ suites:
   - name: default
     run_list:
       - recipe[hashicorp-vault::default]
+
+  - name: no_cert_mgmt
+    run_list:
+      - recipe[hashicorp-vault::default]
+    attributes:
+      vault:
+        config:
+          tls_disable: '1'
+          manage_certificate: false
+
+  - name: tls_disable
+    run_list:
+      - recipe[hashicorp-vault::default]
+    attributes:
+      vault:
+        config:
+          tls_disable: '1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,8 @@ default['vault']['version'] = '0.2.0'
 
 default['vault']['config']['path'] = '/home/vault/.vault.json'
 default['vault']['config']['address'] = '127.0.0.1:8200'
+# Chef-vault required for certificate management
+default['vault']['config']['manage_certificate'] = true
 default['vault']['config']['tls_cert_file'] = '/etc/vault/ssl/certs/vault.crt'
 default['vault']['config']['tls_key_file'] = '/etc/vault/ssl/private/vault.key'
 

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -38,9 +38,12 @@ module VaultCookbook
       attribute(:statsd_addr, kind_of: String)
       attribute(:backend_type, default: 'inmem', equal_to: %w{consul inmem zookeeper file})
       attribute(:backend_options, option_collector: true)
+      attribute(:manage_certificate, kind_of: [TrueClass, FalseClass], default: true)
 
       def tls?
-        tls_disable.match(/^$/)
+        return true if tls_disable.match(/^$/) && manage_certificate
+
+        false
       end
 
       # Transforms the resource into a JSON format which matches the
@@ -71,7 +74,10 @@ module VaultCookbook
               mode '0755'
             end
 
-            item = chef_vault_item(new_resource.bag_name, new_resource.bag_item)
+            item = chef_vault_item(
+              new_resource.bag_name,
+              new_resource.bag_item
+            )
             file new_resource.tls_cert_file do
               content item['certificate']
               mode '0644'

--- a/test/integration/no_cert_mgmt/serverspec/default_spec.rb
+++ b/test/integration/no_cert_mgmt/serverspec/default_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe file('/etc/vault/ssl/certs/vault.crt') do
+  it { is_expected.to_not be_file }
+end
+
+describe file('/etc/vault/ssl/private/vault.key') do
+  it { is_expected.to_not be_file }
+end

--- a/test/integration/tls_disable/serverspec/default_spec.rb
+++ b/test/integration/tls_disable/serverspec/default_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe file('/home/vault/.vault.json') do
+  describe '#content' do
+    subject { super().content }
+    it { is_expected.to include '"tls_disable": "1"' }
+  end
+end
+
+describe file('/etc/vault/ssl/certs/vault.crt') do
+  it { is_expected.to_not be_file }
+end
+
+describe file('/etc/vault/ssl/private/vault.key') do
+  it { is_expected.to_not be_file }
+end


### PR DESCRIPTION
The prescription by this cookbook to manage the TLS certificate, using chef-vault, is overly strong, and, while it is an excellent practice, may not jibe with some potential users’ workflows.

Builds on #4 to use the `VaultConfig#tls?` method to control whether or not the certificate files are managed. All credit to @zarry!