### PR TITLE
Pin chef-vault to specific ref

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
-cookbook 'chef-vault', git: 'https://github.com/johnbellone/chef-vault-cookbook'
+
 metadata
+
+cookbook 'chef-vault', github: 'chef-cookbooks/chef-vault', ref: '902a089'


### PR DESCRIPTION
Using the HEAD of a cookbook project is a bit dangerous, since it’s a moving target.

We need some features/fixes that are only available in unreleased code for chef-vault.

Choosing a known-good ref is the next best thing to using a released version.