### PR TITLE
Change the default config path to "/etc/vault/vault.json"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['vault']['bag_item'] = 'vault'
 
 default['vault']['version'] = '0.5.0'
 
-default['vault']['config']['path'] = '/home/vault/.vault.json'
+default['vault']['config']['path'] = '/etc/vault/vault.json'
 default['vault']['config']['address'] = '127.0.0.1:8200'
 default['vault']['config']['manage_certificate'] = true
 default['vault']['config']['tls_cert_file'] = '/etc/vault/ssl/certs/vault.crt'

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -17,8 +17,8 @@ describe 'hashicorp-vault::default' do
   end
 
   it { expect(chef_run).to create_poise_service_user('vault').with(group: 'vault') }
-  it { expect(chef_run).to create_vault_config('/home/vault/.vault.json') }
-  it { expect(chef_run).to enable_vault_service('vault').with(config_path: '/home/vault/.vault.json') }
+  it { expect(chef_run).to create_vault_config('/etc/vault/vault.json') }
+  it { expect(chef_run).to enable_vault_service('vault').with(config_path: '/etc/vault/vault.json') }
   it { expect(chef_run).to start_vault_service('vault') }
   context 'with default attributes' do
     it 'converges successfully' do


### PR DESCRIPTION
This is a backward incompatible change and probably, it should be merged only in the scope of next major version of coobook.

I think it is better to put Vault server configuration to `/etc`, according to FHS conventions and best practices from other projects (for example, [consul](https://github.com/johnbellone/consul-cookbook/))