### PR TITLE
Configure "tls_cert_file" and "tls_key_file" paths only if TLS is enabled

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -41,7 +41,7 @@ module VaultCookbook
       attribute(:manage_certificate, kind_of: [TrueClass, FalseClass], default: true)
 
       def tls?
-        return true unless %w{1 true}.include?(tls_disable) && manage_certificate
+        return true unless %w{1 true}.include?(tls_disable)
 
         false
       end
@@ -50,7 +50,8 @@ module VaultCookbook
       # Vault service's configuration format.
       # @see https://vaultproject.io/docs/config/index.html
       def to_json
-        listener_keeps = %i{address tls_cert_file tls_key_file}
+        listener_keeps = %i{address}
+        listener_keeps += %i{tls_cert_file tls_key_file} if tls?
         listener_options = to_hash.keep_if do |k, _|
           listener_keeps.include?(k.to_sym)
         end
@@ -65,7 +66,7 @@ module VaultCookbook
 
       action(:create) do
         notifying_block do
-          if new_resource.tls?
+          if new_resource.tls? && new_resource.manage_certificate
             include_recipe 'chef-vault::default'
 
             [new_resource.tls_cert_file, new_resource.tls_key_file].each do |dirname|


### PR DESCRIPTION
If TLS is disabled explicitly (with `tls_disable` option), then `tls_cert_file` and `tls_key_file` became rendered as empty strings. ~~It causes a Vault server start failure.~~ (_not sure_)
These options should not present in the config file if TLS is disabled.