### PR TITLE
Coerce tls_disable attribute to a string.

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -54,7 +54,7 @@ module VaultCookbook
         listener_options = to_hash.keep_if do |k, _|
           listener_keeps.include?(k.to_sym)
         end
-        listener_options[:tls_disable] = tls_disable unless tls?
+        listener_options[:tls_disable] = tls_disable.to_s unless tls?
         config_keeps = %i{disable_mlock statsite_addr statsd_addr}
         config = to_hash.keep_if do |k, _|
           config_keeps.include?(k.to_sym)


### PR DESCRIPTION
- Enable Boolean and Fixnum values (which are legal as values in a Ruby hash and a Vagrantfile's `chef.json`) to the String values expected by the cookbook's attribute parser.
- Fix issue #40.