### PR TITLE
Fix logic and tests for external TLS certificate management

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,8 +30,8 @@ suites:
     attributes:
       vault:
         config:
-          tls_disable: '1'
-          manage_certificate: true
+          tls_disable: '0'
+          manage_certificate: false
 
   - name: tls_disable
     run_list:

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -41,9 +41,7 @@ module VaultCookbook
       attribute(:manage_certificate, kind_of: [TrueClass, FalseClass], default: true)
 
       def tls?
-        return true unless %w{1 true}.include?(tls_disable) && manage_certificate
-
-        false
+        ! %w{1 true}.include?(tls_disable)
       end
 
       # Transforms the resource into a JSON format which matches the
@@ -65,7 +63,7 @@ module VaultCookbook
 
       action(:create) do
         notifying_block do
-          if new_resource.tls?
+          if new_resource.tls? && new_resource.manage_certificate
             include_recipe 'chef-vault::default'
 
             [new_resource.tls_cert_file, new_resource.tls_key_file].each do |dirname|
@@ -106,7 +104,7 @@ module VaultCookbook
 
       action(:delete) do
         notifying_block do
-          if new_resource.tls?
+          if new_resource.tls? && new_resource.manage_certificate
             file new_resource.tls_cert_file do
               action :delete
             end

--- a/test/integration/no_cert_mgmt/serverspec/default_spec.rb
+++ b/test/integration/no_cert_mgmt/serverspec/default_spec.rb
@@ -1,5 +1,12 @@
 require 'spec_helper'
 
+describe file('/home/vault/.vault.json') do
+  describe '#content' do
+    subject { super().content }
+    it { is_expected.to_not include '"tls_disable": "1"' }
+  end
+end
+
 describe file('/etc/vault/ssl/certs/vault.crt') do
   it { is_expected.to_not be_file }
 end


### PR DESCRIPTION
There are three possible scenarios for TLS configuration:
1. TLS enabled and certs managed by this cookbook (via chef-vault)
2. TLS enabled and certs managed outside this cookbook (via certmonger, for example)
3. TLS disabled (where cert management is irrelevant)

The "no_cert_mgmt" suite in .kitchen.yml is ostensibly intended to test scenario 2, but it is currently testing the degenerate case where certificates are managed by the chef-vault (manage_certificate = true) but TLS is disabled. The tls? method is also problematic as written: if the manage_certificate attribute is only examined in this boolean function for TLS, then there can only ever be two scenarios handled.

This patch simplifies the tls? method to only cover top-level TLS enable/disable, moves inspection of the manage_certificate attribute into the blocks that actually manage the certificate files, and explicitly checks that TLS is enabled in scenario 2 above.