### PR TITLE
Fixed typo in vault_config provider property

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -46,7 +46,7 @@ module VaultCookbook
       attribute(:backend_options, option_collector: true)
       attribute(:habackend_type, kind_of: String)
       attribute(:habackend_options, option_collector: true)
-      attribute(:telemetry_options, options_collector: true, default: {})
+      attribute(:telemetry_options, option_collector: true, default: {})
 
       def tls?
         if tls_disable == true || tls_disable == 'yes' || tls_disable == 1


### PR DESCRIPTION
Re-submitting fix contained in #45 

This PR for johnbellone/rubyzip-cookbook#1 should be merged as well. Otherwise Chef clients `< 12.5` won't be able to use this cookbook.