### PR TITLE
Added a resource for reading secrets from Vault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: ruby
 notifications:
   slack: bloomberg-rnd:BvYmxrV9xj902XWTRNrkLNkR
 script: bundle exec rake travis
+before_install:
+  - gem update bundler
+  - gem update berkshelf
+  - gem update --system
 rvm:
   - 2.2
 branches:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,10 @@
 #
 # Copyright 2015-2016, Bloomberg Finance L.P.
 #
+default['hashicorp-vault']['gems'] = {
+  vault: '0.4.0'
+}
+
 default['hashicorp-vault']['service_name'] = 'vault'
 default['hashicorp-vault']['service_user'] = 'vault'
 default['hashicorp-vault']['service_group'] = 'vault'

--- a/libraries/vault_secret.rb
+++ b/libraries/vault_secret.rb
@@ -1,0 +1,101 @@
+#
+# Cookbook: hashicorp-vault
+# License: Apache 2.0
+#
+# Copyright 2015-2016, Bloomberg Finance L.P.
+#
+require 'poise'
+
+# Inspiration from sethvargo's gist
+module VaultCookbook
+  module Resource
+    # A `vault_secret` resource for reading secrets out of Vault
+    # @action read
+    # @provides vault_secret
+    # @since 2.2
+    class VaultSecret < Chef::Resource
+      include Poise(fused: true)
+      provides(:vault_secret)
+      actions(:read)
+      default_action(:read)
+
+      # @!attribute path
+      # The secret path in Vault.
+      # @return [String]
+      attribute(:path, kind_of: String, name_attribute: true)
+      # @!attribute attempts
+      # The number of attempts to try & read a Vault secret.
+      # @return [Fixnum]
+      attribute(:attempts, kind_of: Fixnum, default: 2)
+      # @see https://github.com/hashicorp/vault-ruby
+      attribute(:address, kind_of: String, required: true)
+      attribute(:token, kind_of: String)
+      attribute(:proxy_address, kind_of: String)
+      attribute(:proxy_port, kind_of: String)
+      attribute(:proxy_username, kind_of: String)
+      attribute(:proxy_password, kind_of: String)
+      attribute(:ssl_pem_file, kind_of: String)
+      attribute(:ssl_verify, kind_of: [TrueClass, FalseClass])
+      attribute(:timeout, kind_of: Fixnum)
+      attribute(:ssl_timeout, kind_of: Fixnum)
+      attribute(:open_timeout, kind_of: Fixnum)
+      attribute(:read_timeout, kind_of: Fixnum)
+
+      def config_options
+        %i(address token proxy_address proxy_port proxy_username proxy_password
+           ssl_pem_file ssl_verify timeout ssl_timeout open_timeout read_timeout)
+      end
+
+      def config
+        to_hash.keep_if do |k, _|
+          config_options.include?(k.to_sym)
+        end
+      end
+
+      action(:read) do
+        notifying_block do
+          run_context.include_recipe 'hashicorp-vault::gems'
+
+          lease_id = node[new_resource.path]
+
+          begin
+            client = Vault::Client.new(new_resource.config)
+
+            # We have a lease for this secret, try to renew it
+            unless lease_id.nil?
+              client.sys.renew(lease_id)
+              new_resource.updated_by_last_action(false)
+              return
+            end
+          rescue Vault::HTTPClientError => e
+            # Renewal failed - lease could have been:
+            # manually revoked, or not renewed in time
+            Chef::Log.warn("Failed to renew #{new_resource.path}. Attempting a fresh read.\n" + e.message)
+          end
+
+          begin
+            max_attempts = new_resource.attempts
+            secret = client.with_retries(Vault::HTTPError, Vault::HTTPConnectionError, attempts: max_attempts) do |attempts, error|
+              unless attempts == 0
+                Chef::Log.info "Received exception #{error.class} from Vault - attempt #{attempts}"
+              end
+              client.logical.read(new_resource.path)
+            end
+
+            if secret.nil?
+              Chef::Log.fatal("Could not read secret - #{new_resource.path}")
+              return
+            end
+
+            node.set[new_resource.path] = secret.lease_id if secret.renewable?
+            # Store secret in-memory for the rest of the Chef run
+            node.run_state[new_resource.path] = secret
+            new_resource.updated_by_last_action(true)
+          rescue Vault::HTTPError => e
+            Chef::Log.warn("Failed to read #{new_resource.path}.\n" + e.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook: hashicorp-vault
+# License: Apache 2.0
+#
+# Copyright 2015-2016, Bloomberg Finance L.P.
+#
+node['hashicorp-vault']['gems'].each do |name, vers|
+  chef_gem name do
+    version vers
+    compile_time true if respond_to?(:compile_time)
+  end
+  require name
+end


### PR DESCRIPTION
This resource fetches a secret from Vault & stores it in the node's run_state for the duration the Chef run. It also supports renewing secrets by caching the path on the node object & renewing it on the next Chef run.

```ruby
# Instead of specifying a token property you can also set the token in the VAULT_TOKEN environment variable (safer)
ENV['VAULT_TOKEN'] = 'GUID'

vault_secret 'secret/recipes/burgers' do
  address 'https://vault.example.com'
  token 'GUID'
  ssl_verify false
  attempts 5
  notifies :create, "file[/tmp/test]", :immediately
end

# Example of how to use the fetched secret
file '/tmp/test' do
  action :nothing
  content lazy { node.run_state['secret/recipes/burgers'].data[:ingredients] }
  owner 'root'
  group 'root'
  mode '0640'
end
```