### PR TITLE
Use custom templates for "systemd" and "sysvinit" service providers

### DIFF
--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -90,6 +90,7 @@ module VaultCookbook
         service.environment(new_resource.environment)
         service.restart_on_update(false)
         service.provider(:sysvinit)
+        service.options(:sysvinit, template: 'hashicorp-vault:sysvinit.service.erb')
 
         if node.platform_family?('rhel') && node.platform_version.to_i == 6
           service.provider(:sysvinit)

--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -90,6 +90,7 @@ module VaultCookbook
         service.environment(new_resource.environment)
         service.restart_on_update(false)
         service.options(:sysvinit, template: 'hashicorp-vault:sysvinit.service.erb')
+        service.options(:systemd, template: 'hashicorp-vault:systemd.service.erb')
 
         if node.platform_family?('rhel') && node.platform_version.to_i == 6
           service.provider(:sysvinit)

--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -89,7 +89,6 @@ module VaultCookbook
         service.user(new_resource.user)
         service.environment(new_resource.environment)
         service.restart_on_update(false)
-        service.provider(:sysvinit)
         service.options(:sysvinit, template: 'hashicorp-vault:sysvinit.service.erb')
 
         if node.platform_family?('rhel') && node.platform_version.to_i == 6

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=<%= @name %>
+Wants=network.target
+After=network.target
+
+[Service]
+Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
+ExecStart=<%= @command %>
+ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
+KillSignal=<%= @stop_signal %>
+User=<%= @user %>
+WorkingDirectory=<%= @directory %>
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -1,0 +1,137 @@
+#!/bin/sh
+#
+# <%= @name %> - this script manages the vault server
+#
+# chkconfig: 345 99 70
+# description: this script manages the vault server
+#
+### BEGIN INIT INFO
+# Provides:       <%= @name %>
+# Required-Start: $local_fs $network
+# Required-Stop:  $local_fs $network
+# Default-Start: 3 4 5
+# Default-Stop:  0 1 2 6
+# Short-Description: Manage the vault server
+### END INIT INFO
+
+prog="<%= File.basename(@daemon) %>"
+user="<%= @user %>"
+exec="<%= @daemon %>"
+pidfile="<%= @pid_file %>"
+logfile="/var/log/$prog.log"
+lockfile="/var/lock/subsys/$prog"
+
+<%- @environment.each do |key, val| -%>
+export <%= key %>="<%= val %>"
+<%- end -%>
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
+
+<%- if @platform_family == 'debian' -%>
+. /lib/lsb/init-functions
+
+_start() {
+  touch $logfile
+  chown $user $logfile
+  start-stop-daemon --start --quiet --background \
+      --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
+      --chuid $user --chdir "<%= @directory %>" \
+      --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >> $logfile 2>&1"
+}
+
+_stop() {
+  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @stop_signal %>"
+}
+
+_status() {
+  status_of_proc -p $pidfile $exec $prog
+}
+
+_reload() {
+  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @reload_signal %>"
+}
+
+<%- else -%>
+. /etc/rc.d/init.d/functions
+
+_start() {
+    [ -x $exec ] || exit 5
+
+    umask 077
+    touch $pidfile $logfile
+    chown $user $pidfile $logfile
+
+    echo -n $"Starting <%= @name %>: "
+    daemon \
+         --pidfile=$pidfile \
+         --user=$user \
+         " { $exec <%= @daemon_options %> &>> $logfile & } ; echo \$! >| $pidfile "
+     RETVAL=$?
+     echo
+     [ $RETVAL -eq 0 ] && touch $lockfile
+     return $RETVAL
+}
+
+_stop() {
+    echo -n $"Stopping <%= @name %>: "
+    killproc -p $pidfile $exec -<%= @stop_signal %>
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f $lockfile $pidfile
+    return $RETVAL
+}
+
+_status() {
+    status -p $pidfile -l $prog $exec
+}
+
+_reload() {
+    echo -n $"Reloading <%= @name %>: "
+    killproc -p $pidfile $exec -<%= @reload_signal %>
+    echo
+}
+<%- end -%>
+
+_restart() {
+    _stop
+    while :
+    do
+        ss -pl | fgrep "((\"$prog\"," > /dev/null
+        [ $? -ne 0 ] && break
+        sleep 0.1
+    done
+    _start
+}
+
+_status_q() {
+    _status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        _status_q && exit 0
+        _start
+        ;;
+    stop)
+        _status_q || exit 0
+        _stop
+        ;;
+    restart|force-reload)
+        _restart
+        ;;
+    reload)
+        _status_q || exit 7
+        _reload
+        ;;
+    status)
+        _status
+        ;;
+    condrestart|try-restart)
+        _status_q || exit 0
+        _restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+
+exit $?


### PR DESCRIPTION
* Add custom template for "sysvinit" service provider. Purposes are the same as in https://github.com/johnbellone/consul-cookbook/pull/266
* Add custom template for "systemd" service provider. Purposes are the same as in https://github.com/johnbellone/consul-cookbook/commit/66bf9389c81011abca23b65898e82e9e783c1508
* Don't force "sysvinit" to be a service provider for all platforms. 
There is no any reference to the reason why the provider has been hard-coded here. Probably, it was just a typo in https://github.com/johnbellone/vault-cookbook/commit/093f198e5ed73baeb308d4a5cae7e30f40794f65#diff-224e63197dffc5bf0dae729286b58f64R92. Please, correct if it is not so.