### PR TITLE
Prevent "vault" service to be restarted on update

### DIFF
--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -88,7 +88,7 @@ module VaultCookbook
         service.directory(new_resource.directory)
         service.user(new_resource.user)
         service.environment(new_resource.environment)
-        service.restart_on_update(true)
+        service.restart_on_update(false)
         service.provider(:sysvinit)
 
         if node.platform_family?('rhel') && node.platform_version.to_i == 6


### PR DESCRIPTION
Vault server restart is even more harmful than consul restart (related: https://github.com/johnbellone/consul-cookbook/issues/288).

Vault server restart means that Vault becomes sealed and stops process incoming requests. So, regardless of the reason, it should be done only by an operator.