### PR TITLE
Fix default value of "leases" attribute

### DIFF
--- a/libraries/vault_secret.rb
+++ b/libraries/vault_secret.rb
@@ -60,7 +60,7 @@ module VaultCookbook
         notifying_block do
           run_context.include_recipe 'hashicorp-vault::gems'
 
-          node.default_unless['hashicorp-vault']['leases'] = []
+          node.default_unless['hashicorp-vault']['leases'] = {}
           lease_id = node['hashicorp-vault']['leases'][new_resource.path]
 
           begin


### PR DESCRIPTION
It fixes an error:
```
           ================================================================================
           Error executing action `read` on resource 'vault_secret[secret/secretpath]'
           ================================================================================

           TypeError
           ---------
           no implicit conversion of String into Integer

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_secret.rb:66:in `[]'
           /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_secret.rb:66:in `block (2 levels) in <class:VaultSecret>'
           /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/subcontext_block.rb:54:in `instance_eval'
           /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/subcontext_block.rb:54:in `subcontext_block'
           /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/notifying_block.rb:67:in `notifying_block'
           /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_secret.rb:60:in `block in <class:VaultSecret>'
```

That was my bad, introduced by https://github.com/johnbellone/vault-cookbook/pull/56. I'm sorry 😞 