### PR TITLE
Vault 0.5.3 update (with test fixes, build-essential update)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,5 +36,3 @@ suites:
       hashicorp-vault:
         installation:
           provider: git
-      go:
-        version: '1.6'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,3 +36,5 @@ suites:
       hashicorp-vault:
         installation:
           provider: git
+      go:
+        version: '1.6'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['hashicorp-vault']['service_name'] = 'vault'
 default['hashicorp-vault']['service_user'] = 'vault'
 default['hashicorp-vault']['service_group'] = 'vault'
 
-default['hashicorp-vault']['version'] = '0.5.2'
+default['hashicorp-vault']['version'] = '0.5.3'
 
 default['hashicorp-vault']['config']['path'] = '/etc/vault/vault.json'
 default['hashicorp-vault']['config']['address'] = '127.0.0.1:8200'

--- a/libraries/vault_installation_binary.rb
+++ b/libraries/vault_installation_binary.rb
@@ -99,6 +99,7 @@ module VaultCookbook
           when '0.5.0' then 'a0c783b6e4c5aa8c34c0570f836b02ae7d9781fc42d5996a8c3621fec7e47508'
           when '0.5.1' then 'b28a68ce1c6403092485ed17622fd127180559e26cefb1ff7c6bd539319294fd'
           when '0.5.2' then '0a7bf80f41cff7928acf99450b5de0f18472b83e985087b1a45fd6d078707dc8'
+          when '0.5.3' then '6f7384b2a65ec44b5a3ce4da04f8c6e29756462f12eff2f126b2e43790d0e3c9'
           end
         when 'darwin-amd64'
           case resource.version
@@ -111,18 +112,22 @@ module VaultCookbook
           when '0.5.0' then '8f5ca5927f876737566a23442f098afa1ed3dc9d5b238c3c8f7563e06ab6c64c'
           when '0.5.1' then '0466e5a0bfe777586ce4c9b3dfa9f48bbc6e902550aefbb2281725a3bd46179c'
           when '0.5.2' then '48bf1d66cc3b81293186fd458f63fc2b02344aec5f1490c9b9a2915831c13d33'
+          when '0.5.3' then '31e7eff07c202cf2166ac63457054da59a1f4f49e7ad079b38316efadbb79e32'
           end
         when 'freebsd-i386'
           case resource.version
           when '0.5.2' then 'b14aa86a1573125fb0521800e53d04bbfa1f2d5c4fee5cfe62ab42c45ff941ef'
+          when '0.5.3' then '2b534ac83808e1b69a683083c0c8037c992c364ec2df593f829688de4c43d457'
           end
         when 'freebsd-amd64'
           case resource.version
           when '0.5.2' then '63182658c91dacc7edb180b3e68365c928c74a6384d8837b57271d64deecd2b4'
+          when '0.5.3' then 'fd791ba3053a3a6bd622da23590c88c37f97cb86926f2bcab1108a1933aeb862'
           end
         when 'freebsd-arm'
           case resource.version
           when '0.5.2' then 'fcccb3ef43de09861cafc7971b8276558cfc420dca8308c136c74176169213ef'
+          when '0.5.3' then 'a3a1304fe7815d3f8e67e2fa095466456f2e6655f45a0461cb668774b8fd8464'
           end
         when 'linux-i386'
           case resource.version
@@ -135,6 +140,7 @@ module VaultCookbook
           when '0.5.0' then 'af416f99627f5d9d9516a86a6ec75e7b4056c11548951051d178a46171ea6b00'
           when '0.5.1' then '6b3c34bfff2af7fdb15c98a8b7eb59e12316db733e66c4ebdc3c2f09b9f31280'
           when '0.5.2' then '8305303aa9f4a0654961d0930d40bc61b3a0ad52e12d630e1619815de196e9fc'
+          when '0.5.3' then '3ab3cd3ef72bdeea15291fb91436aee745c037d719c4e177d0290c884f325daf'
           end
         when 'linux-amd64'
           case resource.version
@@ -147,6 +153,7 @@ module VaultCookbook
           when '0.5.0' then 'f81accce15313881b8d53b039daf090398b2204b1154f821a863438ca2e5d570'
           when '0.5.1' then '7319b6514cb5ca735d9886d7b7e1ed8730ee38b238bb1626564436b824206d12'
           when '0.5.2' then '7517b21d2c709e661914fbae1f6bf3622d9347b0fe9fc3334d78a01d1e1b4ec2'
+          when '0.5.3' then 'fddb97507f8b539534620882f3a46984160778950e4884831c0f7c2a82b65f52'
           end
         when 'linux-arm'
           case resource.version
@@ -159,6 +166,7 @@ module VaultCookbook
           when '0.5.0' then '722bf424694a60b5608af1bc2b5563ee06cedc03697d2ebc45676e8caf4e9f75'
           when '0.5.1' then '2cc0b40de5d0869b39e0a3fd7de308e6365b823a825a9d743dda0d3783d61655'
           when '0.5.2' then '458da2f7e65e7d03efad56bd60e1e747d303f94bee48ecfe8fe45d4207896142'
+          when '0.5.3' then 'ee2e967e2473fd3868e78383e94e16e53a7c865372b3fc3bb42e1848a75dfa89'
           end
         when 'windows-i386'
           case resource.version
@@ -171,6 +179,7 @@ module VaultCookbook
           when '0.5.0' then '19afa686c438f9af5620aa091682f71f7f8284ab246f5d4701cba408833f8b5f'
           when '0.5.1' then '89e59dbe26146d1e3b17b122185d51737a383bb27cf407a25e13896fb7802e90'
           when '0.5.2' then '714a7f20051147e5424f3e4d4e3cf45a98eecf829175c3acf83001a57f33b990'
+          when '0.5.3' then 'a7ca96079796d022a071f65cde96745f6511d7b1a84f70f2bac06885e16c09fa'
           end
         when 'windows-amd64'
           case resource.version
@@ -183,6 +192,7 @@ module VaultCookbook
           when '0.5.0' then '47b02247d8f7c4944ffcca006b2a25124065d4e9e416494b177a2c0d3165b4e6'
           when '0.5.1' then '1f16b5203ab6e99970b983850ee775c85fed9fa3e558847cdd8b66138ccb17ae'
           when '0.5.2' then '6e718ca8af49785d0614ab6b35d584152e77da80ed8de7100d0929b354133e77'
+          when '0.5.3' then 'a7ca96079796d022a071f65cde96745f6511d7b1a84f70f2bac06885e16c09fa'
           end
         end
       end

--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -71,7 +71,10 @@ module VaultCookbook
           end
 
           package 'libcap2-bin' do
-            only_if { platform?('ubuntu') && node['platform_version'].split('.')[0] == '12' }
+            only_if do
+              (platform?('ubuntu') && node['platform_version'].split('.')[0] == '12') ||
+                (platform?('debian') && node['platform_version'].split('.')[0] == '7')
+            end
           end
 
           execute "setcap cap_ipc_lock=+ep #{new_resource.program}" do

--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -70,6 +70,8 @@ module VaultCookbook
             group new_resource.group
           end
 
+          # libcap2-bin provides set/getcap; not installed by default in
+          # ubuntu ~ 12 and debian < 8
           package 'libcap2-bin' do
             only_if do
               (platform?('ubuntu') && node['platform_version'].split('.')[0] == '12') ||

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook for installing and configuring Vault.'
 long_description 'Application cookbook for installing and configuring Vault.'
-version '2.2.0'
+version '2.3.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.4'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports 'centos', '>= 6.4'
 supports 'windows'
 supports 'freebsd'
 
-depends 'build-essential', '~> 2.2'
+depends 'build-essential', '~> 3.2'
 depends 'golang', '~> 1.7'
 depends 'poise', '~> 2.6'
 depends 'poise-service', '~> 1.1'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe file('/opt/vault/0.5.2/vault') do
+describe file('/opt/vault/0.5.3/vault') do
   it { should be_file }
   it { should be_executable }
 end

--- a/test/unit/libraries/vault_service_spec.rb
+++ b/test/unit/libraries/vault_service_spec.rb
@@ -11,10 +11,10 @@ describe VaultCookbook::Resource::VaultService do
   let(:chefspec_options) { {platform: 'ubuntu', version: '14.04', log_level: :debug} }
 
   before do
-    stub_command("getcap /opt/vault/0.5.2/vault|grep cap_ipc_lock+ep").and_return(false)
+    stub_command("getcap /opt/vault/0.5.3/vault|grep cap_ipc_lock+ep").and_return(false)
   end
 
   context 'with default properties' do
-    it { is_expected.to run_execute 'setcap cap_ipc_lock=+ep /opt/vault/0.5.2/vault' }
+    it { is_expected.to run_execute 'setcap cap_ipc_lock=+ep /opt/vault/0.5.3/vault' }
   end
 end

--- a/test/unit/libraries/vault_service_spec.rb
+++ b/test/unit/libraries/vault_service_spec.rb
@@ -8,7 +8,7 @@ describe VaultCookbook::Resource::VaultService do
   step_into(:vault_service)
   recipe 'hashicorp-vault::default'
 
-  let(:chefspec_options) { {platform: 'ubuntu', version: '14.04', log_level: :debug} }
+  let(:chefspec_options) { { platform: 'ubuntu', version: '14.04', log_level: :debug } }
 
   before do
     stub_command("getcap /opt/vault/0.5.3/vault|grep cap_ipc_lock+ep").and_return(false)

--- a/test/unit/recipes/default_spec.rb
+++ b/test/unit/recipes/default_spec.rb
@@ -4,8 +4,8 @@ require 'chefspec/cacher'
 
 describe 'hashicorp-vault::default' do
   before do
-    stub_command('test -L /opt/vault/0.5.2/vault').and_return(true)
-    stub_command('getcap /opt/vault/0.5.2/vault|grep cap_ipc_lock+ep').and_return(false)
+    stub_command('test -L /opt/vault/0.5.3/vault').and_return(true)
+    stub_command('getcap /opt/vault/0.5.3/vault|grep cap_ipc_lock+ep').and_return(false)
   end
 
   context 'with default node attributes' do
@@ -15,7 +15,7 @@ describe 'hashicorp-vault::default' do
 
     it { expect(chef_run).to create_poise_service_user('vault').with(group: 'vault') }
     it { expect(chef_run).to create_vault_config('/etc/vault/vault.json') }
-    it { expect(chef_run).to create_vault_installation('0.5.2') }
+    it { expect(chef_run).to create_vault_installation('0.5.3') }
     it { expect(chef_run).to enable_vault_service('vault').with(config_path: '/etc/vault/vault.json') }
     it { expect(chef_run).to start_vault_service('vault') }
   end


### PR DESCRIPTION
This change:

* adds support for Vault 0.5.3
* fix for missing `libcap2-bin` package, required for Debian 7.x kitchen test
* added extra steps needed to compile Vault from source, including a dependency on Go 1.6, path fixes, and a `godep restore` stage
* update the dependency on `build-essential ~> 3.2`