### PR TITLE
Liberate "build-essential" version constraint

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports 'centos', '>= 6.4'
 supports 'windows'
 supports 'freebsd'
 
-depends 'build-essential', '~> 3.2'
+depends 'build-essential'
 depends 'golang', '~> 1.7'
 depends 'poise', '~> 2.6'
 depends 'poise-service', '~> 1.1'


### PR DESCRIPTION
As far as I can see, there is no any reason to pin `build-essential` version in this cookbook. However, it may cause some conflicts with other cookbooks, like I've noticed here: https://github.com/johnbellone/vault-cookbook/pull/62#issuecomment-227196449

`build-essential` is one of fundamental library cookbook used by a lot of other cookbooks as a dependency. So, if it's really needed, then it's better for users to pin `build-essential` version on the top level, like wrapper cookbook, env cookbook, or Chef Environment, according to release notes
https://github.com/chef-cookbooks/build-essential/blob/master/CHANGELOG.md