### PR TITLE
Create work dir before service starts as it does not persist across restarts

### DIFF
--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -5,8 +5,7 @@ After=network.target
 
 [Service]
 Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
-PermissionsStartOnly=true
-ExecStartPre=/bin/mkdir -p <%= @directory %>
+RuntimeDirectory=vault
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -5,6 +5,8 @@ After=network.target
 
 [Service]
 Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir -p <%= @directory %>
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>


### PR DESCRIPTION
As /var/run is mounted as tmpfs in ubuntu 16.04 it doesn't persist across system restarts.
I have made user permissions only apply to the start job, and the pre start job can then create the work dir in /var/run (/run) which is owned by root. Therefore the prestart job runs as root and creates the dir if it doesent already exist.