### PR TITLE
Remove 'godep restore' for vault versions > 0.5.0

### DIFF
--- a/libraries/vault_installation_git.rb
+++ b/libraries/vault_installation_git.rb
@@ -60,7 +60,15 @@ module VaultCookbook
           end
 
           # Use godep to restore dependencies before attempting to compile
-          ['godep restore', 'make dev'].each do |step|
+          ['godep restore'].each do |step|
+            execute step do
+              cwd options[:git_path]
+              environment(PATH: "#{node['go']['install_dir']}/go/bin:#{node['go']['gobin']}:/usr/bin:/bin",
+                          GOPATH: node['go']['gopath'])
+            end
+          end if new_resource.version < '0.6.0'
+
+          ['make dev'].each do |step|
             execute step do
               cwd options[:git_path]
               environment(PATH: "#{node['go']['install_dir']}/go/bin:#{node['go']['gobin']}:/usr/bin:/bin",


### PR DESCRIPTION
If I try to install vault by using git I get this error.

```bash
           * execute[godep restore] action run
             
             ================================================================================
             Error executing action `run` on resource 'execute[godep restore]'
             ================================================================================
             
             Mixlib::ShellOut::ShellCommandFailed
             ------------------------------------
             Expected process to exit with [0], but received '1'
             ---- Begin output of godep restore ----
             STDOUT: 
             STDERR: godep: open Godeps/Godeps.json: no such file or directory
             ---- End output of godep restore ----
             Ran godep restore returned 1
             
             Cookbook Trace:
             ---------------
             /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
             /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/notifying_block.rb:69:in `notifying_block'
             /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb:40:in `action_create'
             /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
             
             Resource Declaration:
             ---------------------
             # In /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb
             
       64:             execute step do
       65:               cwd options[:git_path]
       66:               environment(PATH: "#{node['go']['install_dir']}/go/bin:#{node['go']['gobin']}:/usr/bin:/bin",
       67:                           GOPATH: node['go']['gopath'])
       68:             end
       69:           end
             
             Compiled Resource:
             ------------------
             # Declared in /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb:64:in `block (2 levels) in action_create'
             
             execute("godep restore") do
        action [:run]
        retries 0
        retry_delay 2
        default_guard_interpreter :execute
        command "godep restore"
        backup 5
        cwd "/opt/go/src/github.com/hashicorp/vault"
        environment {:PATH=>"/usr/local/go/bin:/opt/go/bin:/usr/bin:/bin", :GOPATH=>"/opt/go"}
        returns 0
        declared_type :execute
        cookbook_name "hashicorp-vault"
             end
             
             Platform:
             ---------
             x86_64-linux
             
           
           ================================================================================
           Error executing action `create` on resource 'vault_installation[0.6.0]'
           ================================================================================
           
           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           execute[godep restore] (/tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb line 64) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
           ---- Begin output of godep restore ----
           STDOUT: 
           STDERR: godep: open Godeps/Godeps.json: no such file or directory
           ---- End output of godep restore ----
           Ran godep restore returned 1
           
           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
           /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/notifying_block.rb:69:in `notifying_block'
           /tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb:40:in `action_create'
           /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/hashicorp-vault/recipes/default.rb
           
            12: install = vault_installation node['hashicorp-vault']['version'] do |r|
            13:   if node['hashicorp-vault']['installation']
            14:     node['hashicorp-vault']['installation'].each_pair { |k, v| r.send(k, v) }
            15:   end
            16: end
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/hashicorp-vault/recipes/default.rb:12:in `from_file'
           
           vault_installation("0.6.0") do
             provider VaultCookbook::Provider::VaultInstallationGit
             action [:create]
             updated true
             updated_by_last_action true
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             declared_type :vault_installation
             cookbook_name "hashicorp-vault"
             recipe_name "default"
             version "0.6.0"
             program "/opt/go/src/github.com/hashicorp/vault/bin/vault"
           end
           
           Platform:
           ---------
           x86_64-linux
           
       
       Running handlers:
       [2016-07-08T10:40:29+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2016-07-08T10:40:29+00:00] ERROR: Exception handlers complete
       Chef Client failed. 4 resources updated in 07 seconds
       [2016-07-08T10:40:29+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2016-07-08T10:40:29+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
       [2016-07-08T10:40:29+00:00] ERROR: vault_installation[0.6.0] (hashicorp-vault::default line 12) had an error: Mixlib::ShellOut::ShellCommandFailed: execute[godep restore] (/tmp/kitchen/cache/cookbooks/hashicorp-vault/libraries/vault_installation_git.rb line 64) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
       ---- Begin output of godep restore ----
       STDOUT: 
       STDERR: godep: open Godeps/Godeps.json: no such file or directory
       ---- End output of godep restore ----
       Ran godep restore returned 1
       [2016-07-08T10:40:30+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```