### PR TITLE
Fix init script syntax for compatibility with RHEL/CentOS  5

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -64,7 +64,7 @@ _start() {
     daemon \
          --pidfile=$pidfile \
          --user=$user \
-         " { $exec <%= @daemon_options %> &>> $logfile & } ; echo \$! >| $pidfile "
+         " { $exec <%= @daemon_options %> >> $logfile 2>&1 & } ; echo \$! >| $pidfile "
      RETVAL=$?
      echo
      [ $RETVAL -eq 0 ] && touch $lockfile


### PR DESCRIPTION
There is bash v3.2.* in RHEL/CentOS 5, which doesn't support this notation for stderr and stdout redirection: `&>> `

The following error occurs:

```
Starting vault: bash: -c: line 0: syntax error near unexpected token `>'
bash: -c: line 0: `ulimit -S -c 0 >/dev/null 2>&1 ;  { /opt/vault/0.6.1/vault server -config=/etc/vault/vault.json &>> /var/log/vault.log & } ; echo $! >| /var/run/vault.pid '
                                                           [FAILED]
```

So, we have to use the traditional notation with `2>&1` to keep the compatibility with RHEL/CentOS  5