### PR TITLE
Enable passwordless sudo for tests

### DIFF
--- a/test/fixtures/policies/default.rb
+++ b/test/fixtures/policies/default.rb
@@ -9,3 +9,4 @@ named_run_list :freebsd, 'freebsd::default', run_list
 named_run_list :windows, 'windows::default', run_list
 
 default['authorization']['sudo']['users'] = %w(kitchen vagrant)
+default['authorization']['sudo']['passwordless'] = true


### PR DESCRIPTION
It fixes #78 

In #75 we've forced RHEL/CenOS platforms to be provisioned with `sudo::default` in order to add test users, such as "vagrant" and "kitchen", to `/etc/sudoers`. But that's not enough - we should also enable passwordless sudo for them.

Before:
```
# /etc/sudoers
#...
kitchen ALL=(ALL)
vagrant ALL=(ALL)
```

After:
```
# /etc/sudoers
#...
kitchen ALL=(ALL) NOPASSWD:ALL
vagrant ALL=(ALL) NOPASSWD:ALL
```