### PR TITLE
Add disable_cache config option

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -37,6 +37,7 @@ module VaultCookbook
       attribute(:tls_cert_file, kind_of: String)
       attribute(:tls_key_file, kind_of: String)
       attribute(:cache_size, kind_of: Fixnum)
+      attribute(:disable_cache, equal_to: [true, false], default: false)
       attribute(:disable_mlock, equal_to: [true, false], default: false)
       attribute(:default_lease_ttl, kind_of: String)
       attribute(:max_lease_ttl, kind_of: String)
@@ -61,7 +62,7 @@ module VaultCookbook
       # @see https://vaultproject.io/docs/config/index.html
       def to_json
         # top-level
-        config_keeps = %i{cache_size disable_mlock default_lease_ttl max_lease_ttl}
+        config_keeps = %i{cache_size disable_cache disable_mlock default_lease_ttl max_lease_ttl}
         config = to_hash.keep_if do |k, _|
           config_keeps.include?(k.to_sym)
         end

--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -37,7 +37,7 @@ module VaultCookbook
       attribute(:tls_cert_file, kind_of: String)
       attribute(:tls_key_file, kind_of: String)
       attribute(:cache_size, kind_of: Fixnum)
-      attribute(:disable_cache, equal_to: [true, false], default: false)
+      attribute(:disable_cache, equal_to: [true, false])
       attribute(:disable_mlock, equal_to: [true, false], default: false)
       attribute(:default_lease_ttl, kind_of: String)
       attribute(:max_lease_ttl, kind_of: String)


### PR DESCRIPTION
Addition of vault global config option `disable_cache`.
It's been available since 0.4.0, default setting in vault is `false`.

Fixes #84