### PR TITLE
Fix error due to missing method 'platform_family?'

### DIFF
--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -79,8 +79,8 @@ module VaultCookbook
           end
 
           execute "setcap cap_ipc_lock=+ep #{new_resource.program}" do
-            not_if { platform_family?('windows', 'mac_os_x', 'freebsd') }
-            not_if { platform_family?('rhel') && node['platform_version'].to_i < 6 }
+            not_if { node.platform_family?('windows', 'mac_os_x', 'freebsd') }
+            not_if { node.platform_family?('rhel') && node['platform_version'].to_i < 6 }
             not_if { new_resource.disable_mlock }
             not_if "getcap #{new_resource.program}|grep cap_ipc_lock+ep"
           end
@@ -97,7 +97,7 @@ module VaultCookbook
         service.options(:sysvinit, template: 'hashicorp-vault:sysvinit.service.erb')
         service.options(:systemd, template: 'hashicorp-vault:systemd.service.erb')
 
-        if platform_family?('rhel') && node['platform_version'].to_i == 6
+        if node.platform_family?('rhel') && node['platform_version'].to_i == 6
           service.provider(:sysvinit)
         end
       end


### PR DESCRIPTION
This PR fixes a compatibility issue with Chef 12.6.0 and below.
A Chef run exits with the following error message:
```No resource or method named `platform_family?' for `VaultCookbook::Provider::VaultService ""'```