### PR TITLE
Remove CentOS 5.11 from TestKitchen configuration

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -33,17 +33,6 @@ platforms:
       pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN yum -y install which initscripts
-  - name: centos-5
-    driver:
-      image: centos:5
-      platform: rhel
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN yum -y install which initscripts
-    attributes:
-      hashicorp-vault:
-        config:
-          disable_mlock: true
   - name: ubuntu-16.04
     driver:
       image: ubuntu:16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,12 +14,7 @@ platforms:
   - name: ubuntu-12.04
   - name: centos-7.2
   - name: centos-6.8
-  - name: centos-5.11
-    attributes:
-      hashicorp-vault:
-        config:
-          disable_mlock: true
-
+  
 suites:
   - name: default
     provisioner:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
   matrix:
     - INSTANCE=default-centos-7
     - INSTANCE=default-centos-6
-    - INSTANCE=default-centos-5
     - INSTANCE=default-ubuntu-1604
     - INSTANCE=default-ubuntu-1404
     - INSTANCE=default-ubuntu-1204

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ secrets for your infrastructure.
 The following platforms have been certified with integration tests
 using Test Kitchen:
 
-- CentOS (RHEL) 5.11, 6.8, 7.2
+- CentOS (RHEL) 6.8, 7.2
 - Ubuntu 12.04, 14.04, 16.04
 
 ## Basic Usage


### PR DESCRIPTION
CentOS 5 is deprecated now. Its repodata.xml was moved and this Readme instruction is published on all mirrors:

```
This directory (and version of CentOS) is depreciated.  

CentOS-5 is now past EOL

You can get the last released version of centos 5.11 here:

http://vault.centos.org/5.11/

Please NOTE:  this is not being maintained for security since moving to Vault.
It will have security issues, you should upgrade to a new version instead.
```
http://ftp.uninett.no/centos/5/readme
