### PR TITLE
Set permissions on directories for binary install

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -86,6 +86,9 @@ module VaultCookbook
       action(:create) do
         notifying_block do
           directory ::File.dirname(new_resource.path) do
+            owner new_resource.owner
+            group new_resource.group
+            mode '0750'
             recursive true
           end
 

--- a/libraries/vault_installation_binary.rb
+++ b/libraries/vault_installation_binary.rb
@@ -46,8 +46,14 @@ module VaultCookbook
           basename: options[:archive_basename])
 
         notifying_block do
-          directory ::File.join(options[:extract_to], new_resource.version) do
-            recursive true
+          [
+            options[:extract_to],
+            ::File.join(options[:extract_to], new_resource.version),
+          ].each do |path|
+            directory path do
+              mode '0755'
+              recursive true
+            end
           end
 
           zipfile options[:archive_basename] do

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -11,6 +11,20 @@ describe user('vault') do
   it { should exist }
 end
 
+%w(/opt/vault /opt/vault/0.6.5).each do |path|
+  describe directory(path) do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+end
+
+describe directory('/etc/vault') do
+  it { should exist }
+  its('owner') { should eq 'vault' }
+  its('group') { should eq 'vault' }
+  its('mode') { should cmp '0750' }
+end
+
 describe file('/etc/vault/vault.json') do
   its('mode') { should eq 0640 }
   it { should be_file }


### PR DESCRIPTION
The directories created during the vault binary installation inherit the
file mode permissions from the root user on the system. In environments
where the umask is more restrictive (i.e. 0027) the o+x bit is turned
off for the directories where the `vault` binary and `vault.json`
configuration file live.

This change explicitly sets the file mode permissions for the binary
installation `extract_to` directory and the `/etc/vault` configuration
directory.