### PR TITLE
Add missing Vault versions and update configuration options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['hashicorp-vault']['service_name'] = 'vault'
 default['hashicorp-vault']['service_user'] = 'vault'
 default['hashicorp-vault']['service_group'] = 'vault'
 
-default['hashicorp-vault']['version'] = '0.6.5'
+default['hashicorp-vault']['version'] = '0.8.3'
 
 default['hashicorp-vault']['config']['path'] = '/etc/vault/vault.json'
 default['hashicorp-vault']['config']['address'] = '127.0.0.1:8200'

--- a/libraries/vault_installation_binary.rb
+++ b/libraries/vault_installation_binary.rb
@@ -114,6 +114,14 @@ module VaultCookbook
           when '0.6.3' then '61cffd444bae4e9b8c5c5aa6bba3d4dc9bf6879730295302436be6a996d238f8'
           when '0.6.4' then 'e0ba582c0a7b5d42b44903e0f87267a0262d6d1fe6dc41161c15ef87b48b071f'
           when '0.6.5' then '553d65782a853777e5c954bea262bb6f81ac956e5cedb9e03fd88d07a685d90f'
+          when '0.7.0' then '11d60c33e45ec842876ff7828eb1adf2abe97d1e845f92d7234013171d3a977e'
+          when '0.7.1' then '1209a163aba27f3c1d7baaf08f0b04c1e11527d8d4b0d5b11b0f33503a19f2ca'
+          when '0.7.2' then '1832fba41de86b551674addc87b591708456f68f3b4fe4daf007e08864e4a7ee'
+          when '0.7.3' then '5ab070055bbcad9c59ab32d6f4479b432fcab0934fd4f251e1851bfb01b6487a'
+          when '0.8.0' then '146d287faa8a397788189289acc54957f6899dadc83000d423651556f555b0c7'
+          when '0.8.1' then 'ef835bb803ce45baab97fbe475e62f1124511190631923d4352d04c9e1cecce4'
+          when '0.8.2' then '22e074ae2b7e43c5784b06c1a1c3b0d6a036972d362a5d7ace1cd82e4ad29687'
+          when '0.8.3' then '774747c847be21a599e2e5ff44794397629cc9de19bbd324ffb3402c7574adba'
           end
         when 'darwin-amd64'
           case resource.version
@@ -133,6 +141,14 @@ module VaultCookbook
           when '0.6.3' then 'dc1d97e403177f8cfeee20cac83a2b323cafa80f67bbb048df879ab2a4fdd616'
           when '0.6.4' then '83f680b5e2aaa4c1c2a1a5dbc7479e63186233b6cdda64e24b968f6f1856b676'
           when '0.6.5' then 'abad5d79c3b81e07405c00997ec5d646e171eaab644a3c35354a03eb2d43c8e9'
+          when '0.7.0' then 'db995adf0e46dd7ae43d2fa3523f44a007a6adc37c3a47de5c667a1361cffc13'
+          when '0.7.1' then '9060e4e64b76b566b8ea4f5c76df605292c2aa184b6ec6c1e1fa1afe343e371d'
+          when '0.7.2' then '1b29fabd094ab1afbb26ec6c3df3f7c3deef5ef408bb24db94ae07a330ab5317'
+          when '0.7.3' then 'fa9badde19ba0bb9d7341ac0521593c09ea15a00ed824382c1f58855d2e0959c'
+          when '0.8.0' then 'ae57608c662942bbcf00a05daad60df3f7f2d9f2d672b4e3490498c518704f20'
+          when '0.8.1' then '8efa6ef642edf9fc48a6a7e2b0a24aec9b143369bca90add7724ddcf1e358ffd'
+          when '0.8.2' then '55dd805fa96a0142b941b1e79c16cf02bd3555546ac51c26f8f307e91eeb966d'
+          when '0.8.3' then '43c211d0a2ced793a25ac157cc4f3e2160ea9aa57f8d91f805a51e78a5b0b538'
           end
         when 'freebsd-i386'
           case resource.version
@@ -144,6 +160,14 @@ module VaultCookbook
           when '0.6.3' then '82634a91e494df37ef1509381a859ff1b8c3bd5e3564b3917a53964f7bed27e2'
           when '0.6.4' then 'd1815b0f8cbda1a8b683675e2acaf45a62f2e2f0421b935f78862f5a376e9494'
           when '0.6.5' then '8b9f91a96705772f10fff6ea1106d8714c06e12b4eda3256ff0dcd435a9accb6'
+          when '0.7.0' then 'd215da31431b91e5563152566f818a40df6ee2d07e2a43f5e2561edd95631caf'
+          when '0.7.1' then 'ee6ee44973bb1262c17e77bf364d354fc3b2bf0c858acd49e1cd1ae57d7ff98f'
+          when '0.7.2' then '3a3f9f0187b341718137d5f158387e69778b5862a6f874682ceded25208dd2a1'
+          when '0.7.3' then '9de7796867266623bb4d9151be4d54ded62c0f63c93a32c490d5787589acdbfb'
+          when '0.8.0' then '13b46c16b17b781375739162b662a87050e53e70081247b4c2a64da3c5b01788'
+          when '0.8.1' then 'f05680e765f23d7887aa6c33ea552b52c6f0507377271c2adc45b59f7b6981a2'
+          when '0.8.2' then '9563ad994614113467387734498ea116b8b20791f24c65f52c1cebc14dd97894'
+          when '0.8.3' then 'fea69b39c78493ff03d8744473dc64ec4a95553d34383b138a82058e22c337c6'
           end
         when 'freebsd-amd64'
           case resource.version
@@ -155,6 +179,14 @@ module VaultCookbook
           when '0.6.3' then 'a31ab7468a0ddcc95fd759e24aeec8137911f29ca6af53afabcf62a770d9f0c0'
           when '0.6.4' then '91037896621bc4f234d8545c4407de236680eb7f078c22777afb630ce49ba38b'
           when '0.6.5' then 'df9c8bba6afe118b0fef753f7e3d8a344dfa9a60a008c9bc8d8cc4da60b6b50a'
+          when '0.7.0' then 'c0ee3541cc53b6d1502e2629f24cec64ce5b07b4f867c648755fbdb26075a3b2'
+          when '0.7.1' then '930a8c7c26270e2b535f8342c6e54b879b34b66049d4c1999055e278a6dea098'
+          when '0.7.2' then '3613f8005919265db6afa21f61d1a0847a2efbdc7dd0dd6db08b981313be67ac'
+          when '0.7.3' then '050a7f497ac70ad55a511eef2086b647edc13b0dec103f2fcf37fe0c24b3e11e'
+          when '0.8.0' then 'adee18e186d8ba4ca3fd6fe60801ad2016f4b645944bbe3a2401b54acc3035a5'
+          when '0.8.1' then 'f0bc6b4bf2cb360ecb315084429ee68e3685a57756bcb291cede8058b321cdf2'
+          when '0.8.2' then 'f08dcd9e5f9bc78c258e31ab4e12e819a5d8020132fbce76c5f9a891d2bf26a3'
+          when '0.8.3' then 'c00ef72f67480f79c303f073719b10bf2dc55a5cf72bc8787e592ae5b38496b6'
           end
         when 'freebsd-arm'
           case resource.version
@@ -166,6 +198,14 @@ module VaultCookbook
           when '0.6.3' then 'c19ef6222d195f125a35e11106ce86a9c92d35559849d0b83dd4821a0de31451'
           when '0.6.4' then '4d514acd31f73f26d3c0d5450e5e0fe6b1b1474bb57098167b264165d2b6fdfe'
           when '0.6.5' then '96358370470d13b5843d021a199305e786809f26392ee4f399429017238b0453'
+          when '0.7.0' then 'e74972a2136487e70cb224303ee8a9daebc71162b1b2f1b1dca36489a6105fc0'
+          when '0.7.1' then 'bc5bd7f522f8bc075a5811e491e981066bdb15a40c0a562dd1200a88a0e79f20'
+          when '0.7.2' then '68c67cc3fcfa77da1883eb200cf1829cbaa86f6143df698dd38e99fb4e828839'
+          when '0.7.3' then 'bac8780174cdcb896e8507ca0f41acd38479cbcb6bebf0a893bbbd4cfcbb6a2f'
+          when '0.8.0' then '25ec2c26f037dc9a8b9db97eede0f1ee16f55906da16be974e3aa12af1093d8b'
+          when '0.8.1' then '0850e91f37d7df84b60491d238da3662807b378b20cb7f895713880443948e25'
+          when '0.8.2' then '0e8ccc94e61856aaf9dc548a6a2b51f1e65fa05791578c641ad8b50e33bf5e4e'
+          when '0.8.3' then '67279a3ee4b23bbdc93a1fcf7302ce2405448df291f581a6fdbc45530094036b'
           end
         when 'linux-i386'
           case resource.version
@@ -185,6 +225,14 @@ module VaultCookbook
           when '0.6.3' then '9a5e7eadde0ba31779b81ebf9d012dd6c27edec2a7b8124dba7335d53d367a45'
           when '0.6.4' then '5a3d5fcfb996a576c0c11136cc6e471fe72bb12b5167694919ea95cbca466bd1'
           when '0.6.5' then '85dd505f57964add2359798faca0302877b95386a852331bb0e7d43367a41949'
+          when '0.7.0' then 'b4bcf45ca5fa006a4d7f8e226e0483201c71ee2b7fb01c73db116a4fe6c29c9f'
+          when '0.7.1' then '761783a5a66dddbc74fd87606760379ad992cc4649611ec4ec4fb51c865676eb'
+          when '0.7.2' then 'f43b4d705bf96bc4ebfdeea18e6b9966851d8774c9f7bef0f06c96ffb406815a'
+          when '0.7.3' then 'd66f17811f95ed5ef8f1a4062c7b2781f751ce3e4778c3d00373813159d94afc'
+          when '0.8.0' then '49e7080aed4ebbcf21a9aeb0a3a3c595a2e5435127c9794839f0a9113b28d4c0'
+          when '0.8.1' then 'a2f8ee8e3301487639c62b79c2c9911976c42f2cf55cb6ea4edd9ebb27a7f47b'
+          when '0.8.2' then '8511607aac0be1f5de96b71dbd1fc99bd05c37da048a0633db73840d6f353722'
+          when '0.8.3' then '01d29a91498437027728f382c6e6551e64b380f506e276577c673e998f5aed70'
           end
         when 'linux-amd64'
           case resource.version
@@ -204,6 +252,14 @@ module VaultCookbook
           when '0.6.3' then '8d28c4425e78a00c0f437393b7a87ff00bc3ce1aa0f10ef6538d1ba3181f1d08'
           when '0.6.4' then '04d87dd553aed59f3fe316222217a8d8777f40115a115dac4d88fac1611c51a6'
           when '0.6.5' then 'c9d414a63e9c4716bc9270d46f0a458f0e9660fd576efb150aede98eec16e23e'
+          when '0.7.0' then 'c6d97220e75335f75bd6f603bb23f1f16fe8e2a9d850ba59599b1a0e4d067aaa'
+          when '0.7.1' then 'a576fe2c717ea4b5968477757196ff5308dbded4f5083c91d9e2ea824d2d6fdc'
+          when '0.7.2' then '22575dbb8b375ece395b58650b846761dffbf5a9dc5003669cafbb8731617c39'
+          when '0.7.3' then '2822164d5dd347debae8b3370f73f9564a037fc18e9adcabca5907201e5aab45'
+          when '0.8.0' then '4a0a6fd53ac6913ae78c719113a18cca0569102ce25cfbf1d9e81bdb3c5c508f'
+          when '0.8.1' then '3c4d70ba71619a43229e65c67830e30e050eab7a81ac6b28325ff707e5914188'
+          when '0.8.2' then 'b7050bbc0b9ad554dd03040d1e5ad9c3b0cafde7e781f65433e4db5d05882245'
+          when '0.8.3' then 'a3b687904cd1151e7c7b1a3d016c93177b33f4f9ce5254e1d4f060fca2ac2626'
           end
         when 'linux-arm'
           case resource.version
@@ -223,6 +279,14 @@ module VaultCookbook
           when '0.6.3' then 'c192ad445d0a834047562ddcbc54a353a9ec6ae7fb286416e8180b58af53dcd5'
           when '0.6.4' then '9a12a504088cc4e5b77200273383fec081a7d3df690c04fd13bd7983652c0211'
           when '0.6.5' then 'b97e4da703b93870a614c53431da905029dbb54675f404f6a878536a1852fecf'
+          when '0.7.0' then '0809126db9951c5b31aadf4c538889dc720d398d7f05278f50d794137edb95a9'
+          when '0.7.1' then '4ca79a827ddf1ac11dc1ef4d4ba0f3cd72b24e33f194df3c0bc6fe73ff07bac9'
+          when '0.7.2' then 'bbe3dc39471f95664be90e8210d15dd950a80ff0977fd51209ef5bafe7cf3862'
+          when '0.7.3' then 'd45655f5ccdab762ad37f1efcdfc859f15a09e6ff839a2ba2f2484c173e8903b'
+          when '0.8.0' then '0101bd92bde72385439dcdf7a90bc0eb4ce31218bb67206faae568c5fe6b237f'
+          when '0.8.1' then 'ae05218e62030436894443456d4af21059181cada1c0b570f42b971bec404e78'
+          when '0.8.2' then '2d73c5f26df2cfdfc5b36872d7e651591ebf5e1918735e83b3594886aa46b2c4'
+          when '0.8.3' then 'be59ad54cc2c2f4534c859c3abed2e9749855ba0b30a1f95690616d80d3a81cb'
           end
         when 'windows-i386'
           case resource.version
@@ -242,6 +306,14 @@ module VaultCookbook
           when '0.6.3' then '487e98ff32930f86083286fcd91cad8cb31f6639974eeb8f6c443eb40e5fde1b'
           when '0.6.4' then '1a1d2c6eccc9ce2b9e71c83b222cecbaed71036068e5a7744708821eedefa024'
           when '0.6.5' then 'cfc5a9a7beecdf7e7b8424d706b5f39c1d757f329e6ec490fb627d58f147d51e'
+          when '0.7.0' then '50541390d4de9e8906ad60eab2f527ec18660a5e91c3845f7d15e83416706730'
+          when '0.7.1' then 'efdd4c064af9fe7ec5508ef07075a3c68192cd6a9ed3c68b201bbf9d5cd02112'
+          when '0.7.2' then '0ed812c3a16720058c6e92a9a552ccc5d73c6d8d6fbd89e372a19e57a7b0a185'
+          when '0.7.3' then '6a39b91e72fa8743b76b998ecdf9432acf6f75b98e9975c3f5cad49d5597146d'
+          when '0.8.0' then '5dfb575f7d93b9a44a6ba0be9f0bb35604c7f7636303e2ebc27007b97aa44713'
+          when '0.8.1' then '0a5e1ae2160e7237ebabc970b41e91fc42f5901000dcd185e8e7c74f532cc459'
+          when '0.8.2' then 'a29e86465cca8293f803aed62f25a34295e0ed79122ca855cedc5d3fb6611b12'
+          when '0.8.3' then '1fb1d837a085e1feceae00753b496735db746674ad3c55938f50545d1607dc32'
           end
         when 'windows-amd64'
           case resource.version
@@ -261,6 +333,14 @@ module VaultCookbook
           when '0.6.3' then '56cdfbfee5526def65d29c142dd76eae1451addc11ff3d980a07ccacddb6e142'
           when '0.6.4' then '83db81056e7146513d7a2707ce1b6cf73ae8aa69f942f8cd92da49e1a7de86ca'
           when '0.6.5' then '4ef04179efba3233f1b1fb91c6702a5c7896b1e7d0d7398500a9c0729e81edf7'
+          when '0.7.0' then 'c4d4556665709e0e5b11000413f046e23b365eb97eed9ee04f1a5c2598649356'
+          when '0.7.1' then '27f6f476650d61b1435bd8f24eca97ecabcb789e1e8a0f8388d59ac4f90517ad'
+          when '0.7.2' then '718139c6f4bd918d5f94cd380b7b8db4664915d8d64acba0792a31ba102025a8'
+          when '0.7.3' then '44b9f7b9c87b2c5df71a2462518299bfb165b9c3fd839d2ff817acce9af3a9e4'
+          when '0.8.0' then 'dc9e9fda4cc89050b7a6ff9068acd548db52501be8028bd2f832ad3ef754ef9c'
+          when '0.8.1' then '19f04a5989027245c88ced39032157240a49f186646a4497a15e3cc2a4839ebb'
+          when '0.8.2' then '5395c306bfb033a426f3752a1070ec641372b32134e34f6cd43c53a3f2ed4946'
+          when '0.8.3' then '9cdef19513bc0e8d51a2764505bbcda3b5caa3db83f4fbe2c64cd2d0d6e5779c'
           end
         end
       end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,4 +1,4 @@
-describe file('/opt/vault/0.6.5/vault') do
+describe file('/opt/vault/0.8.3/vault') do
   it { should be_file }
   it { should be_executable }
 end

--- a/test/unit/libraries/vault_service_spec.rb
+++ b/test/unit/libraries/vault_service_spec.rb
@@ -11,10 +11,10 @@ describe VaultCookbook::Resource::VaultService do
   let(:chefspec_options) { { platform: 'ubuntu', version: '14.04', log_level: :debug } }
 
   before do
-    stub_command('getcap /opt/vault/0.6.5/vault|grep cap_ipc_lock+ep').and_return(false)
+    stub_command('getcap /opt/vault/0.8.3/vault|grep cap_ipc_lock+ep').and_return(false)
   end
 
   context 'with default properties' do
-    it { is_expected.to run_execute 'setcap cap_ipc_lock=+ep /opt/vault/0.6.5/vault' }
+    it { is_expected.to run_execute 'setcap cap_ipc_lock=+ep /opt/vault/0.8.3/vault' }
   end
 end

--- a/test/unit/recipes/default_spec.rb
+++ b/test/unit/recipes/default_spec.rb
@@ -4,8 +4,8 @@ require 'chefspec/cacher'
 
 describe 'hashicorp-vault::default' do
   before do
-    stub_command('test -L /opt/vault/0.6.5/vault').and_return(true)
-    stub_command('getcap /opt/vault/0.6.5/vault|grep cap_ipc_lock+ep').and_return(false)
+    stub_command('test -L /opt/vault/0.8.3/vault').and_return(true)
+    stub_command('getcap /opt/vault/0.8.3/vault|grep cap_ipc_lock+ep').and_return(false)
   end
 
   context 'with default node attributes' do
@@ -15,7 +15,7 @@ describe 'hashicorp-vault::default' do
 
     it { expect(chef_run).to create_poise_service_user('vault').with(group: 'vault') }
     it { expect(chef_run).to create_vault_config('/etc/vault/vault.json') }
-    it { expect(chef_run).to create_vault_installation('0.6.5') }
+    it { expect(chef_run).to create_vault_installation('0.8.3') }
     it { expect(chef_run).to enable_vault_service('vault').with(config_path: '/etc/vault/vault.json') }
     it { expect(chef_run).to start_vault_service('vault') }
   end


### PR DESCRIPTION
This change adds all missing Vault versions SHA sums, from 0.7.0 to 0.8.3.
`vault_config` resource is updated to support new configuration options and remove deprecated ones.

This change would break compatibility with Vault < 0.7.0, so I would suggest to bump cookbook major version.

Fixes #100