### PR TITLE
v2.5.1 adding api_addr global attribute to support HA clustering

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -45,6 +45,7 @@ module VaultCookbook
       attribute(:tls_require_and_verify_client_cert, kind_of: String)
       attribute(:tls_client_ca_file, kind_of: String)
       # Global options
+      attribute(:api_addr, kind_of: String)
       attribute(:cluster_name, kind_of: String)
       attribute(:cache_size, kind_of: Integer)
       attribute(:disable_cache, equal_to: [true, false])
@@ -72,7 +73,7 @@ module VaultCookbook
       # @see https://vaultproject.io/docs/config/index.html
       def to_json
         # top-level
-        config_keeps = %i(cluster_name cache_size disable_cache disable_mlock default_lease_ttl max_lease_ttl)
+        config_keeps = %i(api_addr cluster_name cache_size disable_cache disable_mlock default_lease_ttl max_lease_ttl)
         config = to_hash.keep_if do |k, _|
           config_keeps.include?(k.to_sym)
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Application cookbook for installing and configuring Vault.'
 long_description 'Application cookbook for installing and configuring Vault.'
 issues_url 'https://github.com/johnbellone/vault-cookbook/issues'
 source_url 'https://github.com/johnbellone/vault-cookbook/'
-version '2.5.0'
+version '2.5.1'
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'ubuntu', '>= 12.04'


### PR DESCRIPTION
the HA cluster won't start without this global attribute being set. Please review change as I'd rather improve your cookbook than spin off my own fork.