### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,16 +18,16 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen tools.
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+name 'hashicorp-vault'
+
+default_source :supermarket
+
+run_list 'recipe[test::server_json]'
+
+cookbook 'hashicorp-vault', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+named_run_list :server_json, 'recipe[test::server_json]'
+named_run_list :server_hcl, 'recipe[test::server_hcl]'
+named_run_list :server_hcl_ark, 'recipe[test::server_hcl_ark]'
+named_run_list :agent_json, 'recipe[test::agent_json]'
+named_run_list :agent_hcl, 'recipe[test::agent_hcl]'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   chef_license: accept-no-persist
+  policyfile: Policyfile.rb
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -30,17 +31,17 @@ platforms:
 
 suites:
   - name: server_json
-    run_list:
-      - recipe[test::server_json]
+    provisioner:
+      named_run_list: server_json
   - name: server_hcl
-    run_list:
-      - recipe[test::server_hcl]
+    provisioner:
+      named_run_list: server_hcl
   - name: server_hcl_ark
-    run_list:
-      - recipe[test::server_hcl_ark]
+    provisioner:
+      named_run_list: server_hcl_ark
   - name: agent_json
-    run_list:
-      - recipe[test::agent_json]
+    provisioner:
+      named_run_list: agent_json
   - name: agent_hcl
-    run_list:
-      - recipe[test::agent_hcl]
+    provisioner:
+      named_run_list: agent_hcl

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berksfile/Berkshelf usage with Policyfile resolution
- map Kitchen suites to Policyfile named run lists
- update Copilot setup/instructions for chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env RUBYLIB=/Users/damacus/.chef/gem/ruby/3.1.0/gems/hcl-checker-1.6.3/lib GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH_SYSTEM= /opt/chef-workstation/embedded/bin/rspec --format documentation
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list

Kitchen note: server-json-ubuntu-2404 reached converge under Policyfile mode but failed locally fetching https://apt.releases.hashicorp.com/gpg with SSL certificate validation; left for CI confirmation rather than patching unrelated trust-store behavior here.